### PR TITLE
Fix time diff check for reported egg hatch time

### DIFF
--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -4173,11 +4173,11 @@ async def _raidegg(message, content):
         elif res.emoji == '🥚':
             now = datetime.datetime.utcnow() + datetime.timedelta(hours=guild_dict[message.channel.guild.id]['configure_dict']['settings']['offset'])
             start = dateparser.parse(raidegg_split[-1], settings={'PREFER_DATES_FROM': 'future'})
-            if start.day != now.day:
-                if now.hour > 12:
-                    start = start + datetime.timedelta(hours=12)
-                start = start + datetime.timedelta(hours=-24)
+            start = start.replace(month = now.month, day=now.day)
             timediff = relativedelta(start, now)
+            if timediff.hours <= -10:
+                start = start + datetime.timedelta(hours=12)
+                timediff = relativedelta(start, now)
             raidexp = (timediff.hours*60) + timediff.minutes
             if raidexp < 0:
                 await message.channel.send(_('Meowth! Please enter a time in the future.'))

--- a/meowth/__main__.py
+++ b/meowth/__main__.py
@@ -4174,11 +4174,11 @@ async def _raidegg(message, content):
             now = datetime.datetime.utcnow() + datetime.timedelta(hours=guild_dict[message.channel.guild.id]['configure_dict']['settings']['offset'])
             start = dateparser.parse(raidegg_split[-1], settings={'PREFER_DATES_FROM': 'future'})
             if start.day != now.day:
-                if "m" not in raidegg_split[-1]:
+                if now.hour > 12:
                     start = start + datetime.timedelta(hours=12)
-                start = start.replace(day=now.day)
+                start = start + datetime.timedelta(hours=-24)
             timediff = relativedelta(start, now)
-            raidexp = (timediff.hours*60) + timediff.minutes + 1
+            raidexp = (timediff.hours*60) + timediff.minutes
             if raidexp < 0:
                 await message.channel.send(_('Meowth! Please enter a time in the future.'))
                 return


### PR DESCRIPTION
Tested with the following combinations of now timestamp and reported hatch time

##succeed
now = datetime.datetime(2018, 8, 31, 8, 25)
content = "!r 3 donkey bench 9:25"

now = datetime.datetime(2018, 8, 31, 11, 55)
content = "!r 3 donkey bench 12:40"

now = datetime.datetime(2018, 8, 31, 15, 25)
content = "!r 3 donkey bench 4:10"

now = datetime.datetime(2018, 8, 31, 12, 00)
content = "!r 3 donkey bench 13:00"

##fail
now = datetime.datetime(2018, 8, 31, 5, 25)
content = "!r 3 donkey bench 6:40"

now = datetime.datetime(2018, 8, 31, 11, 25)
content = "!r 3 donkey bench 12:40"

now = datetime.datetime(2018, 8, 31, 16, 59)
content = "!r 3 donkey bench 6:05"

now = datetime.datetime(2018, 8, 31, 7, 25)
content = "!r 3 donkey bench 6:40"

now = datetime.datetime(2018, 8, 31, 11, 25)
content = "!r 3 donkey bench 12:26"

now = datetime.datetime(2018, 8, 31, 12, 00)
content = "!r 3 donkey bench 13:00"